### PR TITLE
Add poor hack for sensor_ind wakelock

### DIFF
--- a/arch/arm64/configs/rosy-perf_defconfig
+++ b/arch/arm64/configs/rosy-perf_defconfig
@@ -762,3 +762,6 @@ CONFIG_NTFS_FS=y
 
 # sdcardfs
 CONFIG_SDCARD_FS=y
+
+# poor hack for sensor_ind wakelock
+CONFIG_PM_WAKELOCKS_SENSOR_IND_HACK=y

--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -161,6 +161,18 @@ config PM_RUNTIME
 	  and the bus type drivers of the buses the devices are on are
 	  responsible for the actual handling of the autosuspend requests and
 	  wake-up events.
+	  
+config PM_WAKELOCKS_SENSOR_IND_HACK
+	bool "Poor timeout hack for stuck sensor_ind wakelock"
+	depends on PM_WAKELOCKS
+	default y
+	---help---
+	Adds a very poor hack that converts the sensor_ind wakelock
+	to a timed one on-the-fly. This is unfortunately necessary
+	for broken DSP firmwares on old devices, combined with
+	proprietary sensor binaries which don't account for that.
+	To mitigate this issue, this configuration option applies
+	a timeout to this wakelock.
 
 config PM
 	def_bool y

--- a/kernel/power/wakelock.c
+++ b/kernel/power/wakelock.c
@@ -214,6 +214,12 @@ int pm_wake_lock(const char *buf)
 	if (IS_ERR(wl)) {
 		ret = PTR_ERR(wl);
 		goto out;
+		
+#ifdef CONFIG_PM_WAKELOCKS_SENSOR_IND_HACK
+	if (strncmp(buf, "sensor_ind", 9) == 0)
+		timeout_ns = 2000000000L; /* 2 seconds */
+#endif
+		
 	}
 	if (timeout_ns) {
 		u64 timeout_ms = timeout_ns + NSEC_PER_MSEC - 1;


### PR DESCRIPTION
sensor_ind wakelock stucks on custom roms and make deepsleep not work when the notification led blinking, this commit is needed to fix this issue, trust me sir